### PR TITLE
Fix README toggle instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # STT (Speech To Text)
 
-A simple speech to text system that uses [nvidia/parakeet-tdt-0.6b-v2](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2) under the hood to transcribe speech on keypress.
+A simple speech-to-text system that uses [nvidia/parakeet-tdt-0.6b-v2](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2) under the hood. Dictation mode is toggled with a hotkey.
 
 Uses xdotool to send the text generated as keystrokes into the active application.
-Only tested on Arch Linux. You need to setup a keybind to send a message to a socket file located at `/tmp/sttdict.sock`
+Only tested on Arch Linux. Set up a keybind (e.g. `super+alt+v`) that runs:
+
+```
+echo "toggle" | nc -U /tmp/sttdict.sock
+```
+
+Pressing it again stops dictation. If you set `STT_SOCK_PATH`, update the socket path accordingly.


### PR DESCRIPTION
## Summary
- clarify that dictation is toggled via hotkey
- document example netcat command for toggling
- note `STT_SOCK_PATH` for custom socket path

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7cc52ccc832386847ea181db8019