### PR TITLE
Add PyInstaller build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: package
+package:
+	pyinstaller --onefile main.py

--- a/README.md
+++ b/README.md
@@ -29,3 +29,41 @@ New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\bin\stt.ps1" -Target "C:
 
 Then running `stt` (or `stt.ps1`) will start the application using the
 virtual environment.
+
+## Building a standalone executable
+
+A simple `Makefile` target packages the application using PyInstaller:
+
+```bash
+make package
+```
+
+This runs `pyinstaller --onefile main.py` and places the executable in the `dist/` directory.
+
+### Windows build
+
+1. Create and activate a virtual environment:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+2. Install the requirements and PyInstaller:
+
+```powershell
+pip install -r requirements.txt
+pip install pyinstaller
+```
+
+3. Build the executable:
+
+```powershell
+pyinstaller --onefile main.py
+```
+
+(Or run `make package` if `make` is available.) The resulting `main.exe` will appear under `dist`.
+
+### GPU requirements
+
+The Nemo ASR model works best with a recent NVIDIA GPU and drivers providing CUDA support. CPU inference is possible but significantly slower.


### PR DESCRIPTION
## Summary
- add Makefile with PyInstaller packaging target
- explain how to build on Windows
- document GPU driver requirements

## Testing
- `python -m py_compile main.py`
- `make package` *(fails: pyinstaller not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f832dacc08323b2cd6dfeea4ba64b