### PR TITLE
Use tempdir for runtime files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Uses xdotool to send the text generated as keystrokes into the active applicatio
 Only tested on Arch Linux. Set up a keybind (e.g. `super+alt+v`) that runs:
 
 ```
-echo "toggle" | nc -U /tmp/sttdict.sock
+SOCK=$(python -c "import tempfile, os; print(os.path.join(tempfile.gettempdir(), 'sttdict.sock'))")
+echo "toggle" | nc -U "$SOCK"
 ```
 
 Pressing it again stops dictation. If you set `STT_SOCK_PATH`, update the socket path accordingly.


### PR DESCRIPTION
## Summary
- use tempfile.gettempdir for socket and state paths
- generate troubleshooting notes with dynamic tmpdir
- update README example to compute socket path

## Testing
- `python3 -m py_compile main.py`
- `python3 main.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f84154f14832398c9dbb8357d0d25