### PR TITLE
Add pystray launcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: package
 package:
-	pyinstaller --onefile main.py
+	pyinstaller --onefile tray.py

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\bin\stt.ps1" -Target "C:
 Then running `stt` (or `stt.ps1`) will start the application using the
 virtual environment.
 
+## Tray icon
+
+Launch `python -m tray` to run the program with a small system tray icon.
+Double-click the icon to toggle dictation mode. Right click the icon to exit.
+
 ## Building a standalone executable
 
 A simple `Makefile` target packages the application using PyInstaller:
@@ -41,7 +46,7 @@ A simple `Makefile` target packages the application using PyInstaller:
 make package
 ```
 
-This runs `pyinstaller --onefile main.py` and places the executable in the `dist/` directory.
+This runs `pyinstaller --onefile tray.py` and places the executable in the `dist/` directory.
 
 ### Windows build
 
@@ -62,10 +67,10 @@ pip install pyinstaller
 3. Build the executable:
 
 ```powershell
-pyinstaller --onefile main.py
+pyinstaller --onefile tray.py
 ```
 
-(Or run `make package` if `make` is available.) The resulting `main.exe` will appear under `dist`.
+(Or run `make package` if `make` is available.) The resulting `tray.exe` will appear under `dist`.
 
 ### GPU requirements
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -199,3 +199,4 @@ wrapt==1.17.2
 xdotool==0.4.0
 xxhash==3.5.0
 yarl==1.20.0
+pystray==0.19.5

--- a/tray.py
+++ b/tray.py
@@ -1,0 +1,39 @@
+import threading
+from PIL import Image, ImageDraw
+import pystray
+import main
+
+
+def _create_image():
+    size = 64
+    image = Image.new('RGB', (size, size), 'white')
+    draw = ImageDraw.Draw(image)
+    draw.ellipse((16, 16, 48, 48), fill='black')
+    return image
+
+
+def _toggle(icon=None, item=None):
+    if main.dict_control.toggle():
+        main.try_notify("Dictation started!")
+    else:
+        main.try_notify("Dictation stopped!")
+
+
+def _exit(icon, item):
+    main.shutdown_event.set()
+    icon.stop()
+
+
+def main_tray():
+    threading.Thread(target=main.main, daemon=True).start()
+
+    menu = pystray.Menu(
+        pystray.MenuItem('Toggle dictation', _toggle, default=True),
+        pystray.MenuItem('Exit', _exit)
+    )
+    icon = pystray.Icon('stt', _create_image(), 'STT', menu)
+    icon.run()
+
+
+if __name__ == '__main__':
+    main_tray()


### PR DESCRIPTION
## Summary
- provide `tray.py` which launches `main.main()` in the background
- update packaging to produce a tray executable
- include pystray in requirements
- mention double-click tray icon usage in README

## Testing
- `python3 -m py_compile tray.py`
- `make package` *(fails: pyinstaller not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f893fe28c8323a695d17685029c2f