### PR TITLE
Add toggle helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ A simple speech-to-text system that uses [nvidia/parakeet-tdt-0.6b-v2](https://h
 Uses `xdotool` on Linux to send the text generated as keystrokes. When it is
 unavailable (such as on Windows) the script falls back to the `keyboard` or
 `pyautogui` libraries. Primarily developed on Arch Linux. Set up a keybind
+
 (e.g. `super+alt+v`) that runs:
 
-```
-SOCK=$(python -c "import tempfile, os; print(os.path.join(tempfile.gettempdir(), 'sttdict.sock'))")
-echo "toggle" | nc -U "$SOCK"
+```bash
+python toggle.py toggle
+# or: python -m toggle toggle
 ```
 
 Pressing it again stops dictation. If you set `STT_SOCK_PATH`, update the socket path accordingly.

--- a/toggle.py
+++ b/toggle.py
@@ -1,0 +1,37 @@
+import os
+import socket
+import argparse
+import tempfile
+
+SOCK_PATH = os.environ.get(
+    "STT_SOCK_PATH",
+    os.path.join(tempfile.gettempdir(), "sttdict.sock"),
+)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Send control commands to the running STT instance"
+    )
+    parser.add_argument(
+        "command",
+        choices=["toggle", "stop"],
+        help="Command to send to the STT control socket",
+    )
+    args = parser.parse_args(argv)
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(SOCK_PATH)
+        sock.sendall(args.command.encode())
+    except Exception as e:
+        print(f"[ERROR] {e}")
+        return 1
+    finally:
+        sock.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add a toggle helper to send `toggle`/`stop` commands to the socket
- document new helper usage in the README

## Testing
- `python3 -m py_compile toggle.py main.py tray.py`
- `python3 toggle.py toggle` *(fails: [Errno 2] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f8fde597c8323956a79b08e7e0e5d