### PR TITLE
Handle chmod errors on Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -156,7 +156,10 @@ def socket_listener(sock_path=SOCK_PATH):
     server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
         server.bind(sock_path)
-        os.chmod(sock_path, 0o600)  # Secure socket permissions
+        try:
+            os.chmod(sock_path, 0o600)  # Secure socket permissions
+        except (NotImplementedError, PermissionError):
+            pass
     except OSError as e:
         print(f"[Socket error]: {e}")
         print(f"Try deleting {sock_path} if it exists and re-run.")


### PR DESCRIPTION
## Summary
- ignore `NotImplementedError` and `PermissionError` when setting socket perms

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_683f9131e97883238634b22893b83e0e