### PR TITLE
Add Windows TCP fallback for control socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ python toggle.py toggle
 ```
 
 Pressing it again stops dictation. If you set `STT_SOCK_PATH`, update the socket path accordingly.
+On Windows (where Unix sockets may be unavailable), the code falls back to a
+TCP socket on `localhost:8765`. Override the port with `STT_PORT` if needed.
 
 ## Running the CLI
 

--- a/toggle.py
+++ b/toggle.py
@@ -7,6 +7,7 @@ SOCK_PATH = os.environ.get(
     "STT_SOCK_PATH",
     os.path.join(tempfile.gettempdir(), "sttdict.sock"),
 )
+TCP_PORT = int(os.environ.get("STT_PORT", "8765"))
 
 
 def main(argv=None):
@@ -20,9 +21,14 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    if hasattr(socket, "AF_UNIX"):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        connect_addr = SOCK_PATH
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        connect_addr = ("127.0.0.1", TCP_PORT)
     try:
-        sock.connect(SOCK_PATH)
+        sock.connect(connect_addr)
         sock.sendall(args.command.encode())
     except Exception as e:
         print(f"[ERROR] {e}")


### PR DESCRIPTION
## Summary
- add TCP_PORT env var and use AF_INET socket fallback for Windows
- update toggle script to use AF_INET when AF_UNIX is unavailable
- document STT_PORT in README

## Testing
- `python3 -m py_compile main.py toggle.py tray.py`

------
https://chatgpt.com/codex/tasks/task_e_683fade78280832382d39f8f685e2d22