### PR TITLE
Fix Windows toast error and tray toggle

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,11 @@ def try_notify(msg):
     elif IS_WINDOWS:
         if ToastNotifier is not None:
             try:
-                ToastNotifier().show_toast("STT", msg, threaded=True, duration=3)
+                # Using threaded=False avoids issues with the background
+                # window procedure on newer Python/Windows versions.
+                ToastNotifier().show_toast(
+                    "STT", msg, threaded=False, duration=3
+                )
                 return
             except Exception as e:
                 print(f"[win10toast ERROR] {e}", file=sys.stderr)

--- a/tray.py
+++ b/tray.py
@@ -1,4 +1,5 @@
 import threading
+import socket
 from PIL import Image, ImageDraw
 import pystray
 import main
@@ -13,10 +14,20 @@ def _create_image():
 
 
 def _toggle(icon=None, item=None):
-    if main.dict_control.toggle():
-        main.try_notify("Dictation started!")
+    """Send a toggle command to the running STT instance."""
+    if hasattr(socket, "AF_UNIX"):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        connect_addr = main.SOCK_PATH
     else:
-        main.try_notify("Dictation stopped!")
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        connect_addr = ("127.0.0.1", main.TCP_PORT)
+    try:
+        sock.connect(connect_addr)
+        sock.sendall(b"toggle")
+    except Exception as e:
+        print(f"[Tray toggle error]: {e}")
+    finally:
+        sock.close()
 
 
 def _exit(icon, item):


### PR DESCRIPTION
## Summary
- show Windows toasts synchronously to avoid win10toast crashes
- toggle dictation through the control socket from the tray icon

## Testing
- `python3 -m py_compile main.py tray.py toggle.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb292499c83238fac53824a45a440