### PR TITLE
Fix signal handling when launched via tray thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -486,8 +486,9 @@ def main():
         cleanup()
         sys.exit(0)
 
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
+    if threading.current_thread() is threading.main_thread():
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
 
     try:
         stream = sd.InputStream(


### PR DESCRIPTION
## Summary
- avoid registering signals when main runs outside the main thread

## Testing
- `python -m main --help` *(fails: ModuleNotFoundError: No module named 'pyperclip')*

------
https://chatgpt.com/codex/tasks/task_e_683fb4e5a1888323a287816e8bf8f338